### PR TITLE
Typechecking

### DIFF
--- a/examples/arith.cep
+++ b/examples/arith.cep
@@ -2,8 +2,8 @@ nat: type.
 z: nat.
 s nat: nat.
 
-plus nat nat nat: pred.
-times nat nat nat: pred.
+plus nat nat nat: bwd.
+times nat nat nat: bwd.
 go nat nat: pred.
 output nat: pred.
 

--- a/examples/arith.cep
+++ b/examples/arith.cep
@@ -1,0 +1,27 @@
+nat: type.
+z: nat.
+s nat: nat.
+
+plus nat nat nat: pred.
+times nat nat nat: pred.
+go nat nat: pred.
+output nat: pred.
+
+plus z N N.
+
+plus (s N) M (s P)
+  <- plus N M P.
+
+times z N z.
+
+times (s N) M Q
+  <- plus P M Q
+  <- times N M P.
+
+stage rules {
+  name: go N M * times N M P -o output P.
+}
+
+context init = { go (s (s (s (s (s z))))) (s (s (s z))) }.
+
+#trace _ rules init.

--- a/examples/broadcast.cep
+++ b/examples/broadcast.cep
@@ -13,18 +13,19 @@ broadcast location message : pred.
 stage say = {
   say : says C M * $at C L -o broadcast L M.
 }
-qui * stage say -o stage hear.
 
 restore character location : pred.
 
 stage hear = {
   hear : $broadcast L M * at C L -o knows C M * restore C L.
 }
-qui * stage hear -o stage restore.
 
 stage restore = {
   restore : restore C L -o at C L.
 } 
+
+qui * stage say -o stage hear.
+qui * stage hear -o stage restore.
 
 alice : character.
 bob : character.

--- a/examples/buffy.cep
+++ b/examples/buffy.cep
@@ -21,6 +21,7 @@ friends character character : pred.
 crush character character : pred.
 dating character character : pred.
 dislike character character : pred.
+hunting character character : pred.
 
 place : type.
 crypt : place.

--- a/examples/citysim.cep
+++ b/examples/citysim.cep
@@ -31,7 +31,7 @@ stage sim = {
 
 }
 
-- : qui * stage sim -o stage cleanup.
+qui * stage sim -o stage cleanup.
 
 selected action : pred.
 stage cleanup = {
@@ -40,13 +40,13 @@ stage cleanup = {
 }
 
 tok : pred.
-- : qui * stage cleanup -o stage accept * tok.
+qui * stage cleanup -o stage accept * tok.
 
 stage accept = {
   do/accept : tok * input X -o selected X.
 }
 
-- : qui * stage accept -o stage process.
+qui * stage accept -o stage process.
 
 stage process = {
 
@@ -61,7 +61,7 @@ stage process = {
   do/add_person : money * money * money * selected add_person -o person.
 }
 
-- : qui * stage process -o stage sim * step.
+qui * stage process -o stage sim * step.
 
 context init = {money, money, money, money, money, money, tok, !mill}.
 

--- a/examples/fptp.cep
+++ b/examples/fptp.cep
@@ -9,6 +9,7 @@ elected candidate : pred.
 defeated candidate : pred.
 ballot candidate : pred.
 hopeful candidate nat : pred.
+max nat : pred.
 
 stage count = {
   count_ballot : ballot C * hopeful C N -o hopeful C (s N).
@@ -20,8 +21,6 @@ lt nat nat : bwd.
 lt/z : lt z (s N).
 lt/s : lt (s N) (s M)
       <- lt N M.
-
-max nat : pred.
 
 stage pick = {
   increase : max N * hopeful C N' * lt N N'  

--- a/examples/fptp.cep
+++ b/examples/fptp.cep
@@ -14,7 +14,7 @@ stage count = {
   count_ballot : ballot C * hopeful C N -o hopeful C (s N).
 }
 
-- : qui * stage count -o stage pick * max z.
+qui * stage count -o stage pick * max z.
 
 lt nat nat : bwd.
 lt/z : lt z (s N).
@@ -30,7 +30,7 @@ stage pick = {
                -o max N * !defeated C.
 }
 
-- : qui * stage pick * hopeful C N -o stage done * !elected C.
+qui * stage pick * hopeful C N -o stage done * !elected C.
 
 stage done = {
   cleanup : max _ -o ().

--- a/examples/garden-iter3.cep
+++ b/examples/garden-iter3.cep
@@ -26,7 +26,7 @@ space : type.
 s1 : space. s2 : space. s3 : space. s4 : space.
 s5 : space. s6 : space. s7 : space. s8 : space.
 
-max_space : pred.
+max_space space : pred.
 
 next_space space space : bwd.
 next_space s4 s5.
@@ -38,12 +38,17 @@ empty space : pred.
 plant_at space : pred.
 plant_type_at space plant_type : pred.
 plant_phase_at space plant_phase : pred.
-health_at space : pred.
+health_at space health : pred.
 needs_water space : pred.
 watered space : pred.
 
+nat : type.
+z : nat.
+s nat : nat.
+
 step : pred.
 turns nat : pred.
+day nat : pred.
 
 stage play {
   get_seeds : 

--- a/examples/garden.cep
+++ b/examples/garden.cep
@@ -120,7 +120,7 @@ stage grow = {
 
   drink : has_plant S Type Phase wilting * last_updated S D * $day (s D)
           * $last_watered S D
-          -o plant Type Phase healthy * last_updated S (s D).
+          -o has_plant S Type Phase healthy * last_updated S (s D).
   
   wilt : has_plant S Type Phase healthy * last_updated S D * $day (s D)
           * $last_watered S WaterDay * minus (s D) WaterDay DaysAgo

--- a/examples/gossip.cep
+++ b/examples/gossip.cep
@@ -15,9 +15,9 @@ says person message : message.
 % follow person person
 % repeat person message
 
-knows person message : message.
-posted message : pred.
-not_posted message : pred.
+knows person message : pred.
+posted person message : pred.
+not_posted person message : pred.
 
 stage say = {
 

--- a/examples/mazegen.cep
+++ b/examples/mazegen.cep
@@ -2,7 +2,7 @@
 
 nat : type.
 z : nat.
-s : nat -> nat.
+s nat : nat.
 
 lt nat nat : bwd.
 lt/z : lt z (s N).
@@ -37,6 +37,8 @@ stage unvisit = {
 }
 
 wall_dir : type.
+north : wall_dir.
+west : wall_dir.
 south : wall_dir.
 east : wall_dir.
 wall nat nat wall_dir : pred.

--- a/examples/mazegen.cep
+++ b/examples/mazegen.cep
@@ -37,12 +37,12 @@ stage unvisit = {
 }
 
 wall_dir : type.
-south : dir.
-east : dir.
+south : wall_dir.
+east : wall_dir.
 wall nat nat wall_dir : pred.
 not_in_maze nat nat : pred.
 
-adjacent nat nat dir nat nat : bwd.
+adjacent nat nat wall_dir nat nat : bwd.
 adjacent/e : adjacent X Y east (s X) Y.
 adjacent/w : adjacent (s X) Y west X Y.
 adjacent/s : adjacent X Y south X (s Y).
@@ -54,7 +54,7 @@ stage allWalls = {
 }
 
 unpicked : pred.
-in_wall_list nat nat dir : pred.
+in_wall_list nat nat wall_dir : pred.
 
 qui * stage allWalls -o unpicked * stage traverse.
 

--- a/examples/mazegen2.cep
+++ b/examples/mazegen2.cep
@@ -2,7 +2,7 @@
 
 nat : type.
 z : nat.
-s : nat -> nat.
+s nat : nat.
 
 lt nat nat : bwd.
 lt/z : lt z (s N).
@@ -37,8 +37,10 @@ stage unvisit = {
 }
 
 wall_dir : type.
-south : dir.
-east : dir.
+north : wall_dir.
+west : wall_dir.
+south : wall_dir.
+east : wall_dir.
 wall nat nat wall_dir : pred.
 not_in_maze nat nat : pred.
 
@@ -48,7 +50,7 @@ stage allWalls = {
 }
 
 unpicked : pred.
-in_wall_list nat nat dir : pred.
+in_wall_list nat nat wall_dir : pred.
 in_maze nat nat : pred.
 
 qui * stage allWalls -o unpicked * stage traverse.

--- a/examples/moveGrid.cep
+++ b/examples/moveGrid.cep
@@ -55,6 +55,7 @@ process_fail : qui * stage process * do _ -o stage accept_input * listen.
 process_done : qui * stage process * done -o ().
 
 stage accept_input = {
+  accept : listen * inputCmd Cmd -o do Cmd * got.
 }
 
 accept_succeed : qui * stage accept_input * got -o stage process.

--- a/examples/moveGrid.cep
+++ b/examples/moveGrid.cep
@@ -25,7 +25,7 @@ lake : place.
 entity : type.
 player : entity.
 
-at player place : pred.
+at entity place : pred.
 
 adj place cmd place : bwd.
 adj town north forest.
@@ -37,7 +37,11 @@ adj desert west forest.
 adj forest north castle.
 adj castle south forest.
 
-go dir : pred.
+done : pred.
+do cmd : pred.
+go cmd : pred.
+listen : pred.
+got : pred.
 success : pred.
 
 stage process = {
@@ -50,11 +54,7 @@ process_succeed : qui * stage process * success -o stage accept_input * listen.
 process_fail : qui * stage process * do _ -o stage accept_input * listen.
 process_done : qui * stage process * done -o ().
 
-listen : pred.
-got : pred.
-
 stage accept_input = {
-  accept : listen * inputCmd Cmd -o do Cmd * got.
 }
 
 accept_succeed : qui * stage accept_input * got -o stage process.

--- a/examples/rpg.cep
+++ b/examples/rpg.cep
@@ -1,8 +1,8 @@
 % Hack & slash RPG demo (akin to Twine blog post)
 
-nat : type.
-z : nat.
-s nat : nat.
+nat : type.   #builtin NAT nat.
+z : nat.      #builtin NAT_ZERO z.
+s nat : nat.  #builtin NAT_SUCC s.
 
 nat-option : type.
 none : nat-option.
@@ -43,9 +43,9 @@ cplus/s   : cplus (s N) M T P
 cplus/z   : cplus z M T M.
 
 max_hp nat : bwd.
-- : max_hp (s (s (s (s (s (s (s (s (s z))))))))).
+max_hp (s (s (s (s (s (s (s (s (s z))))))))).
 recharge_hp nat : bwd.
-- : recharge_hp (s (s (s (s (s (s (s (s (s (s z)))))))))).
+recharge_hp (s (s (s (s (s (s (s (s (s (s z)))))))))).
 
 ndays nat : pred.
 health nat : pred.
@@ -63,20 +63,19 @@ sword : weapon.
 mace : weapon.
 grenade : weapon.
 
-damage_of sword (s (s (s (s z)))). % 4
-damage_of mace (s (s (s (s (s z))))). % 5
-damage_of grenade (s (s (s (s (s (s (s (s (s z))))))))). % 10
+damage_of sword 4.
+damage_of mace 5.
+damage_of grenade 10.
 
-% 10
-cost sword (s (s (s (s (s (s (s (s (s (s z)))))))))).
-% 20
-cost mace (s (s (s (s (s (s (s (s (s (s (s (s (s (s (s (s (s (s (s (s z)
-                                        ))))))))))))))))))).
-cost grenade   % 50
-(s (s (s (s (s
-(s (s (s (s (s (s (s (s (s (s (s (s (s (s (s (s (s (s (s (s (s (s (s (s (s 
-  (s (s (s (s (s (s (s (s (s (s (s (s (s (s (s (s (s (s (s (s z))))))))))))
-                       )))))))))))))))))))))))))))))))))))))).
+cost sword 10.
+cost mace 20.
+cost grenade 50.
+
+main_screen : pred.
+shop_screen : pred.
+rest_screen : pred.
+adventure_screen : pred.
+quit : pred.
 
 stage init = {
   i : init_tok * max_hp N
@@ -84,11 +83,6 @@ stage init = {
           * weapon_damage (s (s z)).
 }
 qui * stage init -o stage main * main_screen.
-
-main_screen : pred.
-rest_screen : pred.
-adventure_screen : pred.
-quit : pred.
 
 stage main = {
   do/rest : main_screen -o rest_screen. 
@@ -145,6 +139,10 @@ drop nat : pred.
 win_screen : pred.
 lose_screen : pred.
 die_screen : pred.
+gen_monster : pred.
+try_fight : pred.
+fight_in_progress : pred.
+choice : pred.
 
 % drop_amount M N means a monster of size M can drop N coins
 drop_amount nat nat : bwd.
@@ -157,8 +155,6 @@ stage fight_init = {
 }
 qui * stage fight_init -o stage fight * choice.
 
-try_fight : pred.
-fight_in_progress : pred.
 stage fight_auto = {
   fight/hit
     : try_fight * $fight_in_progress * monster_hp MHP * $weapon_damage D
@@ -179,7 +175,6 @@ stage fight_auto = {
             * subtract HP Size none
             -o die_screen.
 }
-choice : pred.
 qui * stage fight_auto * $fight_in_progress -o stage fight * choice.
 qui * stage fight_auto * $win_screen -o stage win.
 qui * stage fight_auto * $die_screen -o stage die.

--- a/examples/shuffle.cep
+++ b/examples/shuffle.cep
@@ -1,4 +1,16 @@
 
+item : type.
+a : item.
+b : item.
+c : item.
+
+list : type.
+nil : list.
+cons item list : list.
+
+member item : pred.
+list list : pred.
+
 stage shuffle = {
 pick : member E * list L -o list (cons E L).
 }

--- a/examples/simwar.cep
+++ b/examples/simwar.cep
@@ -10,15 +10,15 @@ opponent team team : bwd.
 opponent red black.
 opponent black red.
 
-money team : pred.
-has team unit : pred.
-turn team : pred.
-next_step team : pred.
-
 nat : type.
 z : nat.
 s nat : nat.
 
+money team : pred.
+has team unit : pred.
+turn team : pred.
+next_step team : pred.
+gen_money nat : pred.
 factories team nat : pred.
 
 context init_factories = {factories red (s z), factories black (s z)}.
@@ -84,7 +84,6 @@ stage attackFactory = {
 }
 #interactive attackFactory.
 
-gen_money team nat : pred.
 qui * stage attackFactory * next_step T * $factories T R
   -o stage produce * turn T * gen_money R. 
 qui * stage attackFactory * turn T * $factories T R

--- a/examples/small.cep
+++ b/examples/small.cep
@@ -2,6 +2,7 @@
 
 red : pred.
 blue : pred.
+green : pred.
 
 stage red_blue = {
   r1 : red -o blue.
@@ -23,6 +24,11 @@ context init' = {init, red}.
 location : type.
 start : location.
 end : location.
+l1 : location.
+l2 : location.
+l3 : location.
+l4 : location.
+l5 : location.
 
 element : type.
 r : element.

--- a/examples/social_story_gen.cep
+++ b/examples/social_story_gen.cep
@@ -51,7 +51,7 @@ do/flirt :
 
 do/flirt/conflict :
   $present C * $present C' * $present C'' * $attraction C C' * $attraction C'' C
-  -o eros C' C * anger C'' C * anger C'' C' 
+  -o attraction C' C * anger C'' C * anger C'' C' 
     * sad C''.
 
 % actions dealing with friendship

--- a/examples/sort.cep
+++ b/examples/sort.cep
@@ -7,6 +7,10 @@ lt/z : lt z (s N).
 lt/s : lt (s N) (s M)
      <- lt N M.
 
+list : type.
+nil : list.
+snoc list nat : list.
+
 at nat nat : pred.
 null nat : bwd.
 % "null I" means I is successor of the last
@@ -23,9 +27,6 @@ return list : pred.
 qui * stage sort -o stage collect * collect z nil.
 
 
-list : type.
-nil : list.
-snoc list nat : list.
 
 stage collect = {
   collect/at : collect I L * at I N -o collect (s I) (snoc L N).

--- a/examples/test.yml
+++ b/examples/test.yml
@@ -1,0 +1,41 @@
+succeed:
+ - broadcast.cep
+ - context-test.cep
+ - fptp.cep
+ - gossip.cep
+ - if-rpg.cep
+ - leq.cep
+ - mazegen.cep
+ - mazegen2.cep
+ - negation.cep
+ - numbers.cep
+ - parable.cep
+ - primes.cep
+ - promweek.cep
+ - rpg-tiny.cep
+ - shuffle.cep
+ - small.cep
+ - social_story_gen.cep
+ - sort.cep
+ - tiny.cep
+ - wilds.cep
+
+fail:
+ - hearthstone.cep
+ - paper.cep
+ - sense.cep
+
+nonterm:
+ - arith.cep
+ - citysim.cep
+ - drama_llamas.cep
+ - garden-small.cep
+ - if.cep
+ - interactive-stage-test.cep
+ - moveGrid.cep
+ - rpg.cep
+ - siedler1.cep
+ - siedler_core.cep
+ - simwar.cep
+ - tower_of_hanoi.cep
+ - tragedy.cep

--- a/examples/test.yml
+++ b/examples/test.yml
@@ -29,7 +29,9 @@ nonterm:
  - arith.cep
  - citysim.cep
  - drama_llamas.cep
+ - garden.cep
  - garden-small.cep
+ - garden-iter3.cep
  - if.cep
  - interactive-stage-test.cep
  - moveGrid.cep
@@ -39,3 +41,4 @@ nonterm:
  - simwar.cep
  - tower_of_hanoi.cep
  - tragedy.cep
+ - buffy.cep

--- a/examples/test.yml
+++ b/examples/test.yml
@@ -27,18 +27,18 @@ fail:
 
 nonterm:
  - arith.cep
- - citysim.cep
- - drama_llamas.cep
- - garden.cep
+ - citysim.cep                 SENSE: input is undefined
+ - drama_llamas.cep            XXX: init_ai and friends
+ - garden.cep                  XXX: plant -> has_plant???
  - garden-small.cep
  - garden-iter3.cep
- - if.cep
+ - if.cep                      XXX: too many type errors
  - interactive-stage-test.cep
  - moveGrid.cep
  - rpg.cep
  - siedler1.cep
  - siedler_core.cep
  - simwar.cep
- - tower_of_hanoi.cep
+ - tower_of_hanoi.cep          XXX: don't understand how 'post' is used
  - tragedy.cep
  - buffy.cep

--- a/examples/test.yml
+++ b/examples/test.yml
@@ -16,6 +16,7 @@ succeed:
  - shuffle.cep
  - small.cep
  - social_story_gen.cep
+ - sokoban-checkwins.cep
  - sort.cep
  - tiny.cep
  - wilds.cep
@@ -24,6 +25,7 @@ fail:
  - hearthstone.cep
  - paper.cep
  - sense.cep
+ - tamara/tamara.cep
 
 nonterm:
  - arith.cep
@@ -31,10 +33,12 @@ nonterm:
  - drama_llamas.cep            XXX: init_ai and friends
  - garden.cep                  XXX: plant -> has_plant???
  - garden-small.cep
+ - garden-med.cep
  - garden-iter3.cep
  - if.cep                      XXX: too many type errors
  - interactive-stage-test.cep
  - moveGrid.cep
+ - rpg-tiny.cep
  - rpg.cep
  - siedler1.cep
  - siedler_core.cep

--- a/examples/tiny.cep
+++ b/examples/tiny.cep
@@ -1,2 +1,7 @@
+item : type.
+red item : pred.
+blue item : pred.
+purple item : pred.
+
 r1 : red X -o blue X.
 r2 : red X * $blue X -o purple X.

--- a/examples/tragedy.cep
+++ b/examples/tragedy.cep
@@ -11,12 +11,14 @@ weapon : object.
 % states
 at character location : pred.
 has character object : pred.
+wants character object : pred.
 dead character : pred.
 murdered character character : pred.
 anger character character : pred.
-eros chracter character : pred.
+eros character character : pred.
 philia character character : pred.
 married character character : pred.
+unmarried character : pred.
 neutral character character : pred.
 depressed character : pred.
 suicidal character : pred.

--- a/examples/wilds.cep
+++ b/examples/wilds.cep
@@ -1,3 +1,11 @@
+item : type.
+t : item.
+
+foo item : pred.
+bar item : pred.
+baz item item : pred.
+bla : pred.
+
 stage s = {
   r1 : foo _ -o bar t.
   r2 : baz X _ * bar X -o bla.

--- a/src/ceptre.sml
+++ b/src/ceptre.sml
@@ -20,6 +20,8 @@ structure Ceptre = struct
    | Or of prem * prem
    | One
    | Atom of atom
+  type rule_internal_new = 
+    {name : ident, pivars : int, lhs : prem, rhs : atom list}
   type rule_internal = 
     {name : ident, pivars : int, lhs : atom list, rhs : atom list}
   type context = atom list
@@ -35,6 +37,9 @@ structure Ceptre = struct
   type bwd_rule = 
     {name : ident, pivars : int, 
      head : pred * term list, subgoals : atom list}
+  type bwd_rule_new = 
+    {name : ident, pivars : int, 
+     head : pred * term list, subgoals : prem}
 
   type tp_header = decl list
   datatype builtin = NAT | NAT_ZERO | NAT_SUCC
@@ -58,6 +63,12 @@ structure Ceptre = struct
   fun atomToString (Lin, p, args) = withArgs p (map termToString args)
     | atomToString (Pers, p, args) = withArgs ("!"^p) (map termToString args)
 
+  fun pclassToString class = 
+     case class of
+        Prop => "pred"
+      | Act => "acting"
+      | Sense => "sense"
+      | Bwd => "bwd" 
 
   fun classToString class =
     case class of

--- a/src/csyn.sml
+++ b/src/csyn.sml
@@ -43,7 +43,7 @@ struct
     | Atom of atom
    type fwd_rule = {name: C.ident, lhs: prem, rhs: atom list}
    type bwd_rule = {name: C.ident, subgoals: prem, head: C.pred * term list} 
-   type stage    = {name: C.ident, nondet: C.nondet, body: fwd_rule list} 
+   type stage    = {name: C.ident, body: fwd_rule list} 
 (*
    fun termToString term = 
       case term of
@@ -151,7 +151,6 @@ struct
 
    fun extractStage name tops = 
       {name = name,
-       nondet = C.Random,
        body = map (fn (P.Decl (P.Lolli rule)) => 
                         (extractRule (gensym ()) rule)
                     | (P.Decl (P.Ascribe (P.Id id, P.Lolli rule))) => 

--- a/src/csyn.sml
+++ b/src/csyn.sml
@@ -1,0 +1,208 @@
+structure CSyn =
+struct
+   structure C = Ceptre
+   structure P = Parse
+
+   (* Utility functions *)
+
+   local 
+      val set = ref StringRedBlackSet.empty
+      val gensym_ctr = ref 0
+   in
+   fun remember s = set := StringRedBlackSet.insert (!set) s
+   fun gensym () = 
+   let
+      val count = !gensym_ctr
+      val name = "anon" ^ (Int.toString count)
+      val () = gensym_ctr := count + 1
+   in
+      if StringRedBlackSet.member (!set) name
+         then gensym ()
+      else (remember name; name)
+   end
+   end
+ 
+   fun caps s =
+      case String.explode s of
+         [] => raise Fail ("caps called on empty identifier (internal)")
+       | (c::_) => Char.isUpper c
+
+   (* Syntax *)
+
+   datatype term =
+      Fn of C.ident * term list 
+    | Var of C.ident option
+    | SLit of string
+    | ILit of IntInf.int
+   type atom = C.mode * C.pred * (term list)
+   datatype prem = 
+      Eq of term * term
+    | Neq of term * term
+    | Tensor of prem * prem
+    | One
+    | Atom of atom
+   type fwd_rule = {name: C.ident, lhs: prem, rhs: atom list}
+   type bwd_rule = {name: C.ident, subgoals: prem, head: C.pred * term list} 
+   type stage    = {name: C.ident, nondet: C.nondet, body: fwd_rule list} 
+(*
+   fun termToString term = 
+      case term of
+         Fn (p, []) => p
+       | Fn (p, args) => C.withArgs p (map termToString args)
+       | Var NONE => "_"
+       | Var (SOME id) => id
+       | SLit s => "\""^String.toCString s^"\""
+       | ILit i => IntInf.toString i
+
+   fun atomToString (C.Lin, p, args) = withArgs p (map termToString args)
+     | atomToString (C.Pers, p, args) = withArgs ("!"^p) (map termToString args)
+
+   fun premToString prem =
+      case prem of 
+         Eq (tm1, tm2) => termToString tm1 ^" == "^termToString tm2
+       | Neq (tm1, tm2) => termToString tm1 ^" <> "^termToString tm2
+       | Tensor (prem1, prem2) => premToString prem1 ^" * "^premToString prem2
+       | One => "()"
+       | Atom atom => atomToString atom 
+*)
+
+   datatype csyn =
+      CStage of stage
+    | CRule of fwd_rule 
+    | CCtx of C.ident * atom list
+    | CProg of (int option) * C.ident * C.context 
+    | CType of C.ident
+    | CTerm of C.ident * C.ident list * C.ident
+    | CPred of C.ident * C.ident list * C.predClass
+    | CDecl of C.decl
+    | CBwd of C.bwd_rule
+    | CBuiltin of string * C.builtin
+    | CStageMode of C.ident * C.nondet
+
+   (* Basics: terms and atoms *)
+
+   fun extractID syn =
+      case syn of
+         P.Id id => id
+       | _ => raise Fail ("Expected identifier, found: "^P.synToString syn) 
+
+   fun extractTerm syn =
+      case syn of
+         P.Id id => (if caps id then Var (SOME id) else Fn (id, []))
+       | P.Wild () => Var NONE
+       | P.App (P.Id f, args) => Fn (f, map extractTerm args)
+       | P.Num i => ILit i
+       (* TODO: Add string literals once they're parsed? *)
+       | _ => raise Fail ("Cannot parse as term: "^P.synToString syn) 
+
+   fun extractAtom (perm, syn) = 
+      case syn of 
+         P.Id pred => (perm, pred, [])
+       | P.App (P.Id pred, args) => (perm, pred, map extractTerm args)
+       | _ => raise Fail ("Could not parse as atom: "^P.synToString syn)  
+
+   (* extractDuplciates, extractConj, and extractPrem all need the
+    * same understanding of what a premise looks like.
+    *
+    * extractDuplicates implements the functionality of $atom, which
+    * is syntactic sugar for "atom" appearing both in premise and
+    * conclusion of a rule. *)
+   fun extractDuplicates allowed syn =
+      case syn of
+         P.One () => []
+       | P.Star (syn1, syn2) => 
+         extractDuplicates allowed syn1 @ extractDuplicates allowed syn2
+       | P.Dollar syn => 
+           (if allowed 
+               then [(C.Lin, syn)] 
+            else raise Fail ("Found $ notation where it is not allowed"))
+       | _ => []
+
+   fun extractConj syn =
+      case syn of 
+         P.One () => []
+       | P.Star (syn1, syn2) => extractConj syn1 @ extractConj syn2
+       | P.Bang syn => [ (C.Pers, syn) ]
+       | syn => [ (C.Lin, syn) ]
+
+   fun extractPrem syn = 
+      case syn of
+         P.One () => One
+       | P.Star (syn1, syn2) => Tensor (extractPrem syn1, extractPrem syn2)
+       | P.Unify (syn1, syn2) => Eq (extractTerm syn1, extractTerm syn2)
+       | P.Differ (syn1, syn2) => Neq (extractTerm syn1, extractTerm syn2)
+       | P.Bang syn => Atom (extractAtom (C.Pers, syn))
+       | P.Dollar syn => Atom (extractAtom (C.Lin, syn))
+       | syn => Atom (extractAtom (C.Lin, syn))
+
+   (* Rules, predicates, and contexts *)
+
+   fun extractRule id (lhs, rhs) = 
+      {name = id, lhs = extractPrem lhs, 
+       rhs = map extractAtom (extractConj rhs @ extractDuplicates true lhs)}
+
+   fun extractPred data class = 
+      case data of
+         P.Id id => 
+           (remember id; CPred (id, [], class))
+       | P.App (P.Id id, tms) => 
+           (remember id; CPred (id, map extractID tms, class))
+       | _ => raise Fail ("Expected declaration, got: "^P.synToString data)
+
+   fun extractStage name tops = 
+      {name = name,
+       nondet = C.Random,
+       body = map (fn (P.Decl (P.Lolli rule)) => 
+                        (extractRule (gensym ()) rule)
+                    | (P.Decl (P.Ascribe (P.Id id, P.Lolli rule))) => 
+                        (remember id; extractRule id rule)
+                    | decl => raise Fail ("Only rules can appear in stages.\n"^
+                                          P.topToString "Found: "decl))
+                 tops}
+
+   fun extractContext syn = 
+      case syn of
+         P.Comma (syn1, syn2) => extractContext syn1 @ extractContext syn2
+       | P.Bang syn => [ extractAtom (C.Pers, syn) ]
+       | syn => [ extractAtom (C.Lin, syn) ]
+         
+   (* Declarations, which are potentially ambiguous
+    * 
+    * Because a : v is 
+    *   - A type declaration (a has type v) if v is a type
+    *   - A backward chaining rule (the rule a says v is true) if v is a prop
+    * we pass in the set of known type names to distinguish these cases. *)
+   fun extractDecl types data class = raise Match
+
+   fun extractTop types top =
+      case top of
+         P.Stage (s, tops) =>
+           (remember s; CStage (extractStage s tops))
+       | P.Context (s, NONE) => (remember s; CCtx (s, []))
+       | P.Context (s, SOME syn) => (remember s; CCtx (s, extractContext syn))
+
+       | P.Decl (P.Ascribe (P.Id s, P.Lolli rule)) => 
+           (remember s; CRule (extractRule s rule))
+       | P.Decl (P.Lolli rule) => 
+           (CRule (extractRule (gensym ()) rule))
+
+       | P.Decl (P.Ascribe (P.Id id, P.Id "type")) => (remember id; CType id)
+       | P.Decl (P.Ascribe (data, P.Pred ())) => extractPred data C.Prop
+       | P.Decl (P.Ascribe (data, P.Id "bwd")) => extractPred data C.Bwd
+       | P.Decl (P.Ascribe (data, P.Id "sense")) => extractPred data C.Sense
+       | P.Decl (P.Ascribe (data, P.Id "action")) => extractPred data C.Act
+
+       | P.Decl (P.Ascribe (data, class)) => extractDecl types data class
+       | P.Decl syn => extractDecl types (P.Id (gensym ())) syn 
+
+       | P.Special (directive, args) => raise Match
+           (* case directive of
+                "trace" => CProg (extractTrace args ctxs sg)
+              | "builtin" => CBuiltin (extractBuiltin args sg)
+              | "interactive" =>
+                  (case args of
+                       [Id name] => CStageMode (name, C.Interactive)
+                      | _ => raise IllFormed)
+              | _ => raise IllFormed *)
+
+end

--- a/src/csyn.sml
+++ b/src/csyn.sml
@@ -195,6 +195,7 @@ struct
        | (_, P.Id cid) => CConst (extractCls data cid)
        | (P.Id did, P.Arrow (lhs, rhs)) => 
            (remember did; CBwd (extractBwd (did, extractPrem lhs, rhs)))
+       | (P.Id did, syn) => (remember did; CBwd (extractBwd (did, One, syn)))
        | _ => raise Fail ("Invalid declaration: "^
                           P.synToString (P.Ascribe (data, class)))
 

--- a/src/parse.sml
+++ b/src/parse.sml
@@ -265,7 +265,7 @@ let
 
    (* Debug: print out the parsed file *)
    val () =
-      if false then ()
+      if true then ()
       else app (print o topToString "") tops
 in 
    tops

--- a/src/signature.sml
+++ b/src/signature.sml
@@ -1,0 +1,97 @@
+structure Signature = 
+struct
+   datatype topdecl = 
+      StageDecl     of Ceptre.ident * Ceptre.rule_internal_new list
+    | FwdRuleDecl   of Ceptre.rule_internal_new
+    | CtxDecl       of Ceptre.ident * Ceptre.atom list
+    | TraceDecl     of unit
+    | TypeDecl      of Ceptre.ident
+    | PredDecl      of Ceptre.ident * Ceptre.ident list * Ceptre.predClass
+    | ConstDecl     of Ceptre.ident * Ceptre.ident list * Ceptre.ident
+    | BwdRuleDecl   of Ceptre.bwd_rule_new
+    | BuiltinDecl   of Ceptre.ident * Ceptre.builtin
+    | StageModeDecl of Ceptre.ident * Ceptre.nondet
+ 
+   datatype namespace = 
+      FIRST (* First order data: types and terms *)
+    | PRED (* Predicates and contexts *) 
+    | BUILTIN (* Builtins *) 
+    | STAGE (* Stages *)
+    | RULE (* Both backward-chaining and forward-chaining rules *) 
+    | STAGE_RULE of Ceptre.ident (* Rule in a stage *)
+    | NOTHING
+
+   fun clsToString (id, [], cls) = id^": "^cls
+     | clsToString (id, ids, cls) = id^" "^String.concatWith " " ids^": "^cls
+
+   fun topdeclToString topdecl =
+      case topdecl of
+         StageDecl (id, body) => 
+            "stage "^id^" {\n"^
+            String.concatWith "\n" (map (topdeclToString o FwdRuleDecl) body)^
+            "\n}"
+       | FwdRuleDecl {name, pivars, ...} => 
+            "forward chaining rule "^name^
+            " with "^Int.toString pivars^" free variables..."
+       | CtxDecl (id, ctx) => 
+            "context "^id^" { "^
+            String.concatWith ", " (map Ceptre.atomToString ctx)^" }"          
+       | TraceDecl _ => "#trace ..."
+       | TypeDecl id => id^": type."
+       | PredDecl (a, ids, Ceptre.Prop) => clsToString (a, ids, "pred")^"."  
+       | PredDecl (a, ids, Ceptre.Bwd) => clsToString (a, ids, "bwd")^"."
+       | PredDecl (a, ids, Ceptre.Sense) => clsToString (a, ids, "sense")^"."  
+       | PredDecl (a, ids, Ceptre.Act) => clsToString (a, ids, "action")^"."
+       | ConstDecl (c, ids, cls) => clsToString (c, ids, cls)^"."
+       | BwdRuleDecl {name, pivars, ...} => 
+            "backward chaining rule "^name^
+            " with "^Int.toString pivars^" free variables..."
+       | BuiltinDecl (id, Ceptre.NAT) => "#builtin NAT "^id
+       | BuiltinDecl (id, Ceptre.NAT_ZERO) => "#builtin NAT_ZERO "^id
+       | BuiltinDecl (id, Ceptre.NAT_SUCC) => "#builtin NAT_SUCC "^id
+       | StageModeDecl (id, Ceptre.Interactive) => "#interactive "^id^"."
+       | StageModeDecl (id, _) => "???"
+
+   fun id topdecl = 
+      case topdecl of
+         StageDecl (id, _) => (STAGE, id)
+       | FwdRuleDecl {name, ...} => (RULE, name)
+       | CtxDecl (id, _) => (PRED, id)
+       | TraceDecl _ => (NOTHING, "#trace")
+       | TypeDecl id => (FIRST, id) 
+       | PredDecl (id, _, _) => (PRED, id)
+       | ConstDecl (id, _, _) => (FIRST, id)
+       | BwdRuleDecl {name, ...} => (RULE, name)
+       | BuiltinDecl (_, Ceptre.NAT) => (BUILTIN, "NAT")
+       | BuiltinDecl (_, Ceptre.NAT_ZERO) => (BUILTIN, "NAT_ZERO")
+       | BuiltinDecl (_, Ceptre.NAT_SUCC) => (BUILTIN, "NAT_SUCC")
+       | StageModeDecl _ => (NOTHING, "#interactive?")
+
+   fun describe topdecl = 
+      case topdecl of
+         StageDecl _ => "stage"
+       | FwdRuleDecl _ => "forward-chaining rule"
+       | CtxDecl _ => "context"
+       | TraceDecl _ => "#trace declaration"
+       | TypeDecl _ => "type"
+       | PredDecl (_, _, Ceptre.Prop) => "predicate"
+       | PredDecl (_, _, Ceptre.Bwd) => "backward-chaining predicate"
+       | PredDecl (_, _, Ceptre.Sense) => "sensing preducate"
+       | PredDecl (_, _, Ceptre.Act) => "acting predicate"
+       | ConstDecl (_, _, id) => "constant of type "^id
+       | BwdRuleDecl id => "backward-chaining rule"
+       | BuiltinDecl _ => "#builtin declaration"
+       | StageModeDecl _ => "#interactive declaration"  
+
+   type signat = topdecl list
+   fun add signat topdecl = signat @ [topdecl]
+   fun find signat x = 
+      case (signat, x) of 
+         ([], _) => NONE
+       | (StageDecl (id, body) :: topdecls, (STAGE_RULE id', r)) =>
+            if id = id' then find (map FwdRuleDecl body) (RULE, r)
+            else find topdecls x
+       | (topdecl :: topdecls, _) => 
+            if id topdecl = x then SOME topdecl 
+            else find topdecls x
+end

--- a/src/sources.cm
+++ b/src/sources.cm
@@ -13,6 +13,8 @@ Group is
   ceptre.cmlex.sml
   ceptre.cmyacc.sml
   parse.sml
+  csyn.sml
+  typecheck.sml
   preprocess.sml
   top.sml
   test-harness.sml

--- a/src/sources.cm
+++ b/src/sources.cm
@@ -14,6 +14,7 @@ Group is
   ceptre.cmyacc.sml
   parse.sml
   csyn.sml
+  signature.sml
   typecheck.sml
   preprocess.sml
   top.sml

--- a/src/sources.mlb
+++ b/src/sources.mlb
@@ -12,6 +12,8 @@ exec.sml
 ceptre.cmlex.sml
 ceptre.cmyacc.sml
 parse.sml
+csyn.sml
+
 preprocess.sml
 top.sml
 go.sml

--- a/src/sources.mlb
+++ b/src/sources.mlb
@@ -13,6 +13,7 @@ ceptre.cmlex.sml
 ceptre.cmyacc.sml
 parse.sml
 csyn.sml
+typecheck.sml
 
 preprocess.sml
 top.sml

--- a/src/sources.mlb
+++ b/src/sources.mlb
@@ -13,6 +13,7 @@ ceptre.cmlex.sml
 ceptre.cmyacc.sml
 parse.sml
 csyn.sml
+signature.sml
 typecheck.sml
 
 preprocess.sml

--- a/src/top.sml
+++ b/src/top.sml
@@ -17,7 +17,7 @@ struct
                | _ => types 
            val () = print (Signature.topdeclToString decl^"\n")
         in loop types (Signature.add signat decl) tops end
-    val () = loop StringRedBlackSet.empty [] parsed
+    val () = loop StringRedBlackSet.empty [] parsed 
 
     val (sg:Ceptre.sigma, programs) = Preprocess.process parsed
   in

--- a/src/top.sml
+++ b/src/top.sml
@@ -4,6 +4,21 @@ struct
   fun progs fname =
   let
     val parsed = Parse.parsefile fname
+
+    (* Modified loader to test type checker *)
+    fun loop types signat [] = ()
+      | loop types signat (top :: tops) =
+        let
+           val csyn = CSyn.extractTop types top
+           val decl = TypeCheck.typecheckDecl signat csyn
+           val types =  
+              case decl of 
+                 Signature.TypeDecl a => StringRedBlackSet.insert types a
+               | _ => types 
+           val () = print (Signature.topdeclToString decl^"\n")
+        in loop types (Signature.add signat decl) tops end
+    val () = loop StringRedBlackSet.empty [] parsed
+
     val (sg:Ceptre.sigma, programs) = Preprocess.process parsed
   in
     (sg, programs)

--- a/src/typecheck.sml
+++ b/src/typecheck.sml
@@ -1,0 +1,319 @@
+structure TypeCheck = 
+struct
+   structure CS = CSyn
+   structure S = Signature
+
+   fun pair f {tms, tps} = 
+      case (tms, tps) of 
+         ([], []) => []
+       | (tm :: tms, tp :: tps) => (tm, tp) :: pair f {tms = tms, tps = tps}
+       | ([], _) => raise Fail (f^" was given too few arguments, needs "^
+                                Int.toString (length tps)^" more")
+       | (_, []) => raise Fail (f^" was given "^Int.toString (length tms)^
+                                " too many arguments")
+
+   fun expectedNot id expected decl = 
+      case decl of
+         NONE => raise Fail ("Expected a "^expected^", but "^id^" is undefined")
+       | SOME decl => raise Fail ("Expected a "^expected^
+                                  ", but "^id^" is a "^S.describe decl)
+      
+
+   (*** Variables ***)
+
+   (* Variables are handled in a (relatively inefficient) imperative
+    * style. A vartp of NONE means that, in this position, we're not
+    * allowing any non-ground terms. Otherwise, a vartp is an
+    * association list from identifiers to types, with placeholders
+    * standing in for wildcards. *)
+
+   type vartp = {id: Ceptre.ident option, tp: Ceptre.ident} list ref option
+
+   fun addVar (vartp: vartp) tp = 
+      case vartp of 
+         NONE => raise Fail ("Cannot have a wildcard here")
+       | SOME vars => length (!vars) 
+                      before (vars := !vars @ [ {id = NONE, tp = tp} ])
+
+   fun checkVarList (n, vars) newid newtp =
+      case vars of 
+         [] => (n, [ {id = SOME newid, tp = newtp} ])
+       | {id, tp} :: vars' =>
+           (if id <> SOME newid
+               then let 
+                       val (n', vars') = checkVarList (n+1, vars') newid newtp
+                    in 
+                       (n', {id = id, tp = tp} :: vars') 
+                    end
+            else if tp = newtp 
+               then (n, vars)
+            else raise Fail (newid ^" cannot have type "^newtp^" because it "^
+                             "was elsewhere inferred to have type "^tp))
+
+   fun checkVar (vartp: vartp) id tp = 
+      case vartp of
+         NONE => raise Fail ("Cannot have an unbound variable "^id^" here")
+       | SOME vars => 
+         let val (n, vars') = checkVarList (0, !vars) id tp
+         in 
+            vars := vars';
+            n 
+         end
+
+   fun synthVar (vartp: vartp) newid = 
+      case vartp of 
+         NONE => raise Fail ("Cannot have an unbound variable "^newid^" here")
+       | SOME vars => 
+            Option.map #tp (List.find (fn {id, tp} => id = SOME newid) (!vars))
+
+
+
+   (*** First order data ***)
+
+   fun checkIsType signat id: Ceptre.ident = 
+      case S.find signat (S.FIRST, id) of
+         SOME (S.TypeDecl _) => id
+       | decl => expectedNot id "type" decl
+
+   fun getNatType signat = 
+      case S.find signat (S.BUILTIN, "NAT") of 
+         NONE => raise Fail ("Integer literal used, but builtin NAT "^
+                             "is not defiend.")
+       | SOME (S.BuiltinDecl (tp, Ceptre.NAT)) => tp
+       | _ => raise Fail ("Ill-formed signatre (internal error: NAT)")
+
+   (* Just checks the outer layer of a term for the purported type.
+    * NOT FULL TYPE SYNTHESIS *)
+   fun synthTerm signat vartp tm = 
+      case tm of 
+         CS.Fn (f, tms) => 
+           (case S.find signat (S.FIRST, f) of
+               SOME (S.ConstDecl (_, _, tp)) => SOME tp
+             | decl => expectedNot f "constant" decl)
+       | CS.Var id => Option.mapPartial (synthVar vartp) id
+       | CS.ILit i => SOME (getNatType signat)
+       | CS.SLit s => raise Fail ("No type for string literals") 
+
+   fun checkTerm signat vartp (tm, tp) = 
+      case tm of 
+          CS.Fn (f, tms) => 
+            (case S.find signat (S.FIRST, f) of 
+                SOME (S.ConstDecl (_, tps, tp')) =>
+                  (if tp <> tp' 
+                      then raise Fail (f^" has type "^tp'^
+                                       ", but we expected a "^tp^" here")
+                   else Ceptre.Fn (f, map (checkTerm signat vartp)
+                                         (pair f {tms = tms, tps = tps})))
+              | decl => expectedNot f "constant" decl)
+        | CS.Var NONE => Ceptre.Var (addVar vartp tp)
+        | CS.Var (SOME id) => Ceptre.Var (checkVar vartp id tp)
+        | CS.ILit i => 
+            (if getNatType signat = tp 
+                then Ceptre.ILit i
+             else raise Fail ("Integer literals have type "^getNatType signat^
+                              ", but we expected a "^tp^" here"))
+        | CS.SLit s => raise Fail ("No type for string literals")
+
+
+
+   (*** Propositions and rules ***)
+
+   fun synthMatchingTerms signat vartp thing (tm1, tm2) =
+      case (synthTerm signat vartp tm1, synthTerm signat vartp tm2) of
+          (NONE, NONE) => raise Fail ("Cannot synthesize type of either \
+                                      \term being compared for "^thing)
+        | (SOME tp, NONE) => tp
+        | (NONE, SOME tp) => tp
+        | (SOME tp, SOME tp') => 
+             if tp = tp' then tp 
+             else raise Fail ("The types being compared for "^thing^" don't "^
+                              "match: left hand side has type "^tp^
+                              ", right hand side has type "^tp')
+                        
+   fun checkPrem signat vartp isTop prem = 
+      case prem of 
+         CS.Eq (tm1, tm2) =>
+         let val tp = synthMatchingTerms signat vartp "equality" (tm1, tm2)
+         in Ceptre.Eq (checkTerm signat vartp (tm1, tp), 
+                       checkTerm signat vartp (tm2, tp))
+         end
+       | CS.Neq (tm1, tm2) =>
+         let val tp = synthMatchingTerms signat vartp "inequality" (tm1, tm2)
+         in Ceptre.Neq (checkTerm signat vartp (tm1, tp), 
+                        checkTerm signat vartp (tm2, tp))
+         end
+       | CS.Tensor (prem1, prem2) => 
+            Ceptre.Tensor (checkPrem signat vartp isTop prem1, 
+                           checkPrem signat vartp isTop prem2)
+       | CS.One => Ceptre.One
+
+       (* Special top-level premises *)
+       | CS.Atom (Ceptre.Lin, "qui", []) => 
+            if isTop then Ceptre.Atom (Ceptre.Lin, "qui", [])
+            else raise Fail ("'qui' can only appear in top-level rules")
+       | CS.Atom (_, "qui", []) => 
+            raise Fail ("'qui' must be linear predicate with no arguments")
+       | CS.Atom (Ceptre.Lin, "stage", [ CS.Fn (stage, []) ]) =>
+           ((* case S.find signat (S.STAGE, stage) of
+               SOME (S.StageDecl _) => *)
+                  if isTop 
+                     then Ceptre.Atom (Ceptre.Lin, "stage", 
+                                       [ Ceptre.Fn (stage, []) ])
+                  else raise Fail ("'stage' can only appear in top-level rules")
+            (* | decl => expectedNot stage "stage" decl*))
+       | CS.Atom (_, "stage", _) =>
+            raise Fail ("'stage' must be a linear predicate with one argument")
+
+       | CS.Atom (mode, a, tms) =>  
+           (case S.find signat (S.PRED, a) of 
+               SOME (S.PredDecl (_, _, Ceptre.Act)) =>
+                  raise Fail (a^" is an action predicate and cannot appear "^
+                              "in a premise/left-hand side")
+             | SOME (S.PredDecl (_, tps, _)) =>
+                  Ceptre.Atom (mode, a, map (checkTerm signat vartp) 
+                                            (pair a {tms = tms, tps = tps}))
+             | decl => expectedNot a "predicate" decl)
+
+   fun checkConcAtom signat vartp isTop (mode, a, tms) =
+      case S.find signat (S.PRED, a) of 
+         SOME (S.PredDecl (_, _, Ceptre.Sense)) =>
+            raise Fail (a^" is an sensing predicate and cannot appear in a "^
+                        "conclusion/right-hand side")
+       | SOME (S.PredDecl (_, _, Ceptre.Bwd)) =>
+            raise Fail (a^" is a backward-chaining predicate and "^
+                        "cannot appear in a conclusion/right-hand side")
+       | SOME (S.PredDecl (_, tps, _)) =>
+            (mode, a, map (checkTerm signat vartp) (pair a {tms=tms, tps=tps}))
+       | decl => (* Special top-level conclusions *)
+            (case (mode, a, tms) of 
+                (Ceptre.Lin, "stage", [ CS.Fn (stage, []) ]) =>
+                  ((*case S.find signat (S.STAGE, stage) of 
+                      SOME (S.StageDecl _) => *)
+                         if isTop then (Ceptre.Lin, a, [Ceptre.Fn (stage, [])])
+                         else raise Fail ("'stage' can only appear in "^
+                                          "top-level rules")
+                   (* | decl => expectedNot stage "stage" decl*))
+              | (_, "stage", _) => 
+                   raise Fail ("'stage' must be a linear predicate with "^
+                               "one argument")
+              | _ => expectedNot a "predicate" decl)
+
+   fun checkCtxAtom signat (mode, a, tms) = 
+      case S.find signat (S.PRED, a) of
+         SOME (S.CtxDecl (_, atoms)) => atoms
+       | SOME (S.PredDecl (_, tps, Ceptre.Prop)) =>
+            [ (mode, a, map (checkTerm signat NONE)
+                           (pair a {tms=tms, tps=tps})) ]
+       | SOME (S.PredDecl (_, _, class)) => 
+            raise Fail ("Context must contain only predicates declared as "^
+                        "'pred', but "^a^" is a "^Ceptre.pclassToString class)
+       | decl => expectedNot a "predicate" decl 
+
+   fun checkRule signat isTop {name, lhs, rhs} = 
+   let
+      val vartp = ref []
+      val lhs = checkPrem signat (SOME vartp) isTop lhs
+      val pivars = length (!vartp)
+      val rhs = map (checkConcAtom signat (SOME vartp) isTop) rhs
+      val () = if length (!vartp) = pivars then () 
+               else raise Fail ("Variable "^(case #id (List.last (!vartp)) of
+                                                NONE => "wildcard"
+                                              | SOME id => id)^
+                                " bound in conclusion of "^name^
+                                " but not in premise")
+   in
+      {name = name, pivars = pivars, lhs = lhs, rhs = rhs}
+   end
+
+   fun checkBwd signat {name, subgoals, head = (a, tms)} =
+   let 
+      val vartp = ref []
+      val tms = 
+         case S.find signat (S.PRED, a) of
+            SOME (S.PredDecl (_, tps, Ceptre.Bwd)) =>
+               map (checkTerm signat (SOME vartp)) (pair a {tms=tms, tps=tps})
+          | decl => expectedNot a "backward-chaining predicate" decl
+      val subgoals = checkPrem signat (SOME vartp) false subgoals
+   in
+      {name = name, pivars = length (!vartp),
+       head = (a, tms), 
+       subgoals = subgoals}
+   end
+
+   fun checkStage signat body = 
+      (* XXX TODO check that rule names in body are unique! *)
+      map (checkRule signat false) body
+
+   (*** Signatures ***)
+
+   fun checkUnique signat id desc decl: S.topdecl =
+      case S.find signat id of 
+         SOME decl =>
+            raise Fail ("Cannot redefine "^(#2 id)^" as a "^desc^"; that "^
+                        "identifier is already used as a "^S.describe decl)
+       | NONE => (* Check reserved namespaces *)
+            (case id of 
+                (S.PRED, "qui") => 
+                   raise Fail ("'qui' cannot be declared as a predicate") 
+              | (S.PRED, "stage") => 
+                   raise Fail ("'stage' cannot be declared as a predicate")
+              | _ => decl)
+
+   fun typecheckDecl signat csyn =
+      case csyn of
+         CS.CStage {name, body} => checkUnique signat (S.STAGE, name) "stage" 
+           (S.StageDecl (name, checkStage signat body))
+       | CS.CRule fwd => checkUnique signat (S.RULE, #name fwd) "rule" 
+           (S.FwdRuleDecl (checkRule signat true fwd))
+       | CS.CCtx (name, ctx) => checkUnique signat (S.PRED, name) "context"
+           (S.CtxDecl (name, List.concat (map (checkCtxAtom signat) ctx)))
+       | CS.CTrace _ => (* XXX TODO CHECK WELL-FORMEDNESS OF TRACE DECL *)
+           (S.TraceDecl ())
+       | CS.CType ty => checkUnique signat (S.FIRST, ty) "type" 
+           (S.TypeDecl ty)
+       | CS.CPred (a, tys, cls) => checkUnique signat (S.PRED, a) "predicate" 
+           (S.PredDecl (a, map (checkIsType signat) tys, cls))
+       | CS.CConst (c, tys, cls) => checkUnique signat (S.FIRST, c) "constant"
+           (S.ConstDecl (c, map (checkIsType signat) tys, 
+                         checkIsType signat cls))
+       | CS.CBwd bwd => checkUnique signat (S.RULE, #name bwd) "rule"
+           (S.BwdRuleDecl (checkBwd signat bwd))
+       | CS.CBuiltin (a, Ceptre.NAT) =>
+           (case (S.find signat (S.FIRST, a), 
+                  S.find signat (S.BUILTIN, "NAT")) of 
+               (_, SOME _) => raise Fail "NAT builtin already defined"
+             | (SOME (S.TypeDecl _), NONE) => S.BuiltinDecl (a, Ceptre.NAT)
+             | (decl, NONE) => expectedNot a "type" decl)
+       | CS.CBuiltin (c, Ceptre.NAT_ZERO) =>
+           (case (S.find signat (S.FIRST, c), 
+                  S.find signat (S.BUILTIN, "NAT_ZERO"),
+                  S.find signat (S.BUILTIN, "NAT")) of
+               (_, _, NONE) => raise Fail "NAT builtin not yet defined" 
+             | (_, SOME _, _) => raise Fail "NAT_ZERO builtin already defined"
+             | (SOME (S.ConstDecl (_, [], nat)), NONE, 
+                SOME (S.BuiltinDecl (declared_nat, Ceptre.NAT))) =>
+                 (if nat = declared_nat 
+                     then S.BuiltinDecl (c, Ceptre.NAT_ZERO)
+                  else raise Fail "Wrong type for this to be NAT_ZERO")
+             | (SOME (S.ConstDecl _), NONE, _) =>
+                  raise Fail ("NAT_ZERO builtin must have zero arguments")
+             | (decl, NONE, _) => expectedNot c "constant" decl)
+       | CS.CBuiltin (c, Ceptre.NAT_SUCC) =>
+           (case (S.find signat (S.FIRST, c),
+                  S.find signat (S.BUILTIN, "NAT_SUCC"),
+                  S.find signat (S.BUILTIN, "NAT")) of
+               (_, _, NONE) => raise Fail "NAT builtin not yet defined"
+             | (_, SOME _, _) => raise Fail "NAT_ZERO builtin already defined"
+             | (SOME (S.ConstDecl (_, [nat1], nat2)), NONE,
+                SOME (S.BuiltinDecl (declared_nat, Ceptre.NAT))) => 
+                 (if nat1 = declared_nat andalso nat1 = nat2
+                     then S.BuiltinDecl (c, Ceptre.NAT_SUCC)
+                  else raise Fail "Wrong type for this to be NAT_SUCC")
+             | (SOME (S.ConstDecl _), NONE, _) =>
+                  raise Fail "NAT_SUCC builtin must have one argument"
+             | (decl, NONE, _) => expectedNot c "constant" decl)
+       | CS.CStageMode (stage, nondet_mode) => 
+           (case S.find signat (S.STAGE, stage) of
+               SOME (S.StageDecl _) => S.StageModeDecl (stage, nondet_mode)
+             | decl => expectedNot stage "stage" decl)
+end


### PR DESCRIPTION
Typechecking has been added as a separate pass (it creates a signature that isn't linked in with later stages in the program).

I modified the examples that were obvious how to modify, but you'll really want to check those closely because I don't actually know how all the examples are supposed to work and sometimes moving definitions before their uses was done a little arbitrarily. 

The only typo that might have been breaking things was eros --> atraction in social sim, and a change I made in garden.cep which may or may not have been the right one: I think one instance of "plant" needed to be changed to "has_plant".